### PR TITLE
Remove symbolic link to `gsElasticity/src`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,6 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 set(gismo_MODULES ${gismo_MODULES} $<TARGET_OBJECTS:${PROJECT_NAME}>
   CACHE INTERNAL "G+Smo modules" )
 
-#Symlink include dir (in case your headers are in /src)
-execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/${PROJECT_NAME})
-
-
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}"
   DESTINATION include/gismo
   FILES_MATCHING PATTERN "*.h" )

--- a/examples/aroundCylinder_NS_2D.cpp
+++ b/examples/aroundCylinder_NS_2D.cpp
@@ -3,9 +3,9 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/aroundCylinder_NS_2Dt.cpp
+++ b/examples/aroundCylinder_NS_2Dt.cpp
@@ -6,10 +6,10 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsNsTimeIntegrator.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsNsTimeIntegrator.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 #include <fstream>
 

--- a/examples/aroundCylinder_stokes_2D.cpp
+++ b/examples/aroundCylinder_stokes_2D.cpp
@@ -3,8 +3,8 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/beam_nonLinElast_3D.cpp
+++ b/examples/beam_nonLinElast_3D.cpp
@@ -4,11 +4,11 @@
 /// Authors: O. Weeger (2012-1015, TU Kaiserslautern),
 ///          A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsLinearMaterial.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsLinearMaterial.h>
 
 using namespace gismo;
 

--- a/examples/biceps_activeMuscle_3D.cpp
+++ b/examples/biceps_activeMuscle_3D.cpp
@@ -5,11 +5,11 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsMuscleAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsMuscleAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/biceps_activeMuscle_3Dt.cpp
+++ b/examples/biceps_activeMuscle_3Dt.cpp
@@ -5,11 +5,11 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsMuscleAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsMuscleAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/cooks_mixedLinElast_2D.cpp
+++ b/examples/cooks_mixedLinElast_2D.cpp
@@ -4,8 +4,8 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/cooks_mixedNonLinElast_2D.cpp
+++ b/examples/cooks_mixedNonLinElast_2D.cpp
@@ -4,10 +4,10 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsGeoUtils.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsGeoUtils.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/cooks_nonLinElast_2D.cpp
+++ b/examples/cooks_nonLinElast_2D.cpp
@@ -4,12 +4,12 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsLinearMaterial.h>
-#include <gsElasticity/gsNeoHookeLogMaterial.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsLinearMaterial.h>
+#include <gsElasticity/src/gsNeoHookeLogMaterial.h>
 
 using namespace gismo;
 

--- a/examples/flappingBeam_CFD1_NS_2D.cpp
+++ b/examples/flappingBeam_CFD1_NS_2D.cpp
@@ -6,9 +6,9 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/flappingBeam_CFD3_NS_2Dt.cpp
+++ b/examples/flappingBeam_CFD3_NS_2Dt.cpp
@@ -8,10 +8,10 @@
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 ///
 #include <gismo.h>
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsNsTimeIntegrator.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsNsTimeIntegrator.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/flappingBeam_CSM1_nonLinElast_2D.cpp
+++ b/examples/flappingBeam_CSM1_nonLinElast_2D.cpp
@@ -4,9 +4,9 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/flappingBeam_CSM3_nonLinElast_2Dt.cpp
+++ b/examples/flappingBeam_CSM3_nonLinElast_2Dt.cpp
@@ -4,10 +4,10 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/flappingBeam_FSI2_coupledFSI_2Dt.cpp
+++ b/examples/flappingBeam_FSI2_coupledFSI_2Dt.cpp
@@ -4,15 +4,15 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsNsTimeIntegrator.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsALE.h>
-#include <gsElasticity/gsPartitionedFSI.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsGeoUtils.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsNsTimeIntegrator.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsALE.h>
+#include <gsElasticity/src/gsPartitionedFSI.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsGeoUtils.h>
 
 using namespace gismo;
 

--- a/examples/flappingBeam_meshDeform_2D.cpp
+++ b/examples/flappingBeam_meshDeform_2D.cpp
@@ -6,12 +6,12 @@
 /// The ALE mapping is computed using the nonlinear elasticity method with Jacobian-based local stiffening.
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsGeoUtils.h>
-#include <gsElasticity/gsALE.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsGeoUtils.h>
+#include <gsElasticity/src/gsALE.h>
 
 using namespace gismo;
 

--- a/examples/gsMaterial_test.cpp
+++ b/examples/gsMaterial_test.cpp
@@ -12,8 +12,8 @@
 */
 
 #include <gismo.h>
-#include <gsElasticity/gsMaterialEval.h>
-#include <gsElasticity/gsLinearMaterial.h>
+#include <gsElasticity/src/gsMaterialEval.h>
+#include <gsElasticity/src/gsLinearMaterial.h>
 #include <gsUtils/gsStopwatch.h>
 
 using namespace gismo;

--- a/examples/muscleBeam_activeMuscle_3Dt.cpp
+++ b/examples/muscleBeam_activeMuscle_3Dt.cpp
@@ -5,11 +5,11 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsMuscleAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsMuscleAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/muscleBeam_mixedNonLinElast_3D.cpp
+++ b/examples/muscleBeam_mixedNonLinElast_3D.cpp
@@ -4,9 +4,9 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/muscleBeam_mixedNonLinElast_3Dt.cpp
+++ b/examples/muscleBeam_mixedNonLinElast_3Dt.cpp
@@ -4,11 +4,11 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/plateWithHoleMP_linElast_2D.cpp
+++ b/examples/plateWithHoleMP_linElast_2D.cpp
@@ -7,8 +7,8 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/plateWithHole_linElast_2D.cpp
+++ b/examples/plateWithHole_linElast_2D.cpp
@@ -4,10 +4,10 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsLinearMaterial.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsLinearMaterial.h>
 
 using namespace gismo;
 

--- a/examples/quarterAnnulus_mixedBiharmonic_2D.cpp
+++ b/examples/quarterAnnulus_mixedBiharmonic_2D.cpp
@@ -2,8 +2,8 @@
 ///
 /// Authors: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsBiharmonicAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsBiharmonicAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/rotor_thermalExp_2D.cpp
+++ b/examples/rotor_thermalExp_2D.cpp
@@ -3,8 +3,8 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsThermoAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsThermoAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/rotor_thermalExp_2Dt.cpp
+++ b/examples/rotor_thermalExp_2Dt.cpp
@@ -6,8 +6,8 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsThermoAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsThermoAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/singlePatch_meshDeform_2D.cpp
+++ b/examples/singlePatch_meshDeform_2D.cpp
@@ -2,9 +2,9 @@
 ///
 /// Author: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsGeoUtils.h>
-#include <gsElasticity/gsALE.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsGeoUtils.h>
+#include <gsElasticity/src/gsALE.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/examples/spring_nonLinElast_3D.cpp
+++ b/examples/spring_nonLinElast_3D.cpp
@@ -2,10 +2,10 @@
 ///
 /// Authors: A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsGeoUtils.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsGeoUtils.h>
 
 using namespace gismo;
 

--- a/examples/terrific_linElast_3D.cpp
+++ b/examples/terrific_linElast_3D.cpp
@@ -4,10 +4,10 @@
 /// Authors: O. Weeger (2012-1015, TU Kaiserslautern),
 ///          A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsLinearMaterial.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsLinearMaterial.h>
 
 using namespace gismo;
 

--- a/examples/terrific_nonLinElast_3D.cpp
+++ b/examples/terrific_nonLinElast_3D.cpp
@@ -4,10 +4,10 @@
 /// Authors: O. Weeger (2012-1015, TU Kaiserslautern),
 ///          A.Shamanskiy (2016 - ...., TU Kaiserslautern)
 #include <gismo.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsLinearMaterial.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsLinearMaterial.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 
 using namespace gismo;
 

--- a/src/gsALE.h
+++ b/src/gsALE.h
@@ -14,10 +14,10 @@
 
 #pragma once
 #include <gsIO/gsOptionList.h>
-#include <gsElasticity/gsBaseUtils.h>
+#include <gsElasticity/src/gsBaseUtils.h>
 #include <gsCore/gsMultiPatch.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsBaseAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
 
 namespace gismo
 {

--- a/src/gsALE.hpp
+++ b/src/gsALE.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <gsElasticity/gsALE.h>
+#include <gsElasticity/src/gsALE.h>
 
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsElPoissonAssembler.h>
-#include <gsElasticity/gsBiharmonicAssembler.h>
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsGeoUtils.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElPoissonAssembler.h>
+#include <gsElasticity/src/gsBiharmonicAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsGeoUtils.h>
 #include <gsCore/gsConstantFunction.h>
 
 namespace gismo

--- a/src/gsALE_.cpp
+++ b/src/gsALE_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsALE.h>
-#include <gsElasticity/gsALE.hpp>
+#include <gsElasticity/src/gsALE.h>
+#include <gsElasticity/src/gsALE.hpp>
 
 namespace gismo
 {

--- a/src/gsBaseAssembler.hpp
+++ b/src/gsBaseAssembler.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
 
 namespace gismo
 {

--- a/src/gsBaseAssembler_.cpp
+++ b/src/gsBaseAssembler_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsBaseAssembler.h>
-#include <gsElasticity/gsBaseAssembler.hpp>
+#include <gsElasticity/src/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsBiharmonicAssembler.h
+++ b/src/gsBiharmonicAssembler.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
 
 namespace gismo
 {

--- a/src/gsBiharmonicAssembler.hpp
+++ b/src/gsBiharmonicAssembler.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <gsElasticity/gsBiharmonicAssembler.h>
+#include <gsElasticity/src/gsBiharmonicAssembler.h>
 
 #include <gsPde/gsPoissonPde.h>
-#include <gsElasticity/gsVisitorBiharmonicMixed.h>
+#include <gsElasticity/src/gsVisitorBiharmonicMixed.h>
 
 namespace gismo
 {

--- a/src/gsBiharmonicAssembler_.cpp
+++ b/src/gsBiharmonicAssembler_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsBiharmonicAssembler.h>
-#include <gsElasticity/gsBiharmonicAssembler.hpp>
+#include <gsElasticity/src/gsBiharmonicAssembler.h>
+#include <gsElasticity/src/gsBiharmonicAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsElPoissonAssembler.h
+++ b/src/gsElPoissonAssembler.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
 
 namespace gismo
 {

--- a/src/gsElPoissonAssembler.hpp
+++ b/src/gsElPoissonAssembler.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <gsElasticity/gsElPoissonAssembler.h>
+#include <gsElasticity/src/gsElPoissonAssembler.h>
 
 #include <gsPde/gsPoissonPde.h>
-#include <gsElasticity/gsVisitorElPoisson.h>
+#include <gsElasticity/src/gsVisitorElPoisson.h>
 
 namespace gismo
 {

--- a/src/gsElPoissonAssembler_.cpp
+++ b/src/gsElPoissonAssembler_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsElPoissonAssembler.h>
-#include <gsElasticity/gsElPoissonAssembler.hpp>
+#include <gsElasticity/src/gsElPoissonAssembler.h>
+#include <gsElasticity/src/gsElPoissonAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsElTimeIntegrator.h
+++ b/src/gsElTimeIntegrator.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
-#include <gsElasticity/gsBaseUtils.h>
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseUtils.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
 
 namespace gismo
 {

--- a/src/gsElTimeIntegrator.hpp
+++ b/src/gsElTimeIntegrator.hpp
@@ -15,11 +15,11 @@
 
 #pragma once
 
-#include <gsElasticity/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
 
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsIterative.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
 
 namespace gismo
 {

--- a/src/gsElTimeIntegrator_.cpp
+++ b/src/gsElTimeIntegrator_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsElTimeIntegrator.hpp>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsElTimeIntegrator.hpp>
 
 namespace gismo
 {

--- a/src/gsElasticityAssembler.h
+++ b/src/gsElasticityAssembler.h
@@ -15,11 +15,11 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
-#include <gsElasticity/gsElasticityFunctions.h>
-#include <gsElasticity/gsBaseUtils.h>
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsMaterialContainer.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
+#include <gsElasticity/src/gsElasticityFunctions.h>
+#include <gsElasticity/src/gsBaseUtils.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsMaterialContainer.h>
 
 namespace gismo
 {
@@ -39,7 +39,7 @@ public:
     gsElasticityAssembler(const gsMultiPatch<T> & patches,
                           const gsMultiBasis<T> & basis,
                           const gsBoundaryConditions<T> & bconditions,
-                          const gsFunction<T> & body_force);   
+                          const gsFunction<T> & body_force);
 
     /// @brief Constructor of mixed formulation (displacement + pressure)
     gsElasticityAssembler(const gsMultiPatch<T> & patches,
@@ -53,14 +53,14 @@ public:
                           const gsMultiBasis<T> & basis,
                           const gsBoundaryConditions<T> & bconditions,
                           const gsFunction<T>   & body_force,
-                          const gsMaterialBase<T> * material);   
+                          const gsMaterialBase<T> * material);
 
     /// @brief Constructor for displacement formulation
     gsElasticityAssembler(const gsMultiPatch<T> & patches,
                           const gsMultiBasis<T> & basis,
                           const gsBoundaryConditions<T> & bconditions,
                           const gsFunction<T> & body_force,
-                                gsMaterialContainer<T> materials);   
+                                gsMaterialContainer<T> materials);
 
     /// @brief Returns the list of default options for assembly
     static gsOptionList defaultOptions();

--- a/src/gsElasticityAssembler.hpp
+++ b/src/gsElasticityAssembler.hpp
@@ -15,21 +15,21 @@
 
 #pragma once
 
-#include <gsElasticity/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
 
 #include <gsUtils/gsPointGrid.h>
-#include <gsElasticity/gsBaseUtils.h>
-#include <gsElasticity/gsGeoUtils.h>
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsBaseUtils.h>
+#include <gsElasticity/src/gsGeoUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 // Element visitors
-#include <gsElasticity/gsVisitorLinearElasticity.h>
-#include <gsElasticity/gsVisitorLinearElasticityMM.h>
-#include <gsElasticity/gsVisitorMixedLinearElasticity.h>
-#include <gsElasticity/gsVisitorMixedNonLinearElasticity.h>
-#include <gsElasticity/gsVisitorNonLinearElasticity.h>
-#include <gsElasticity/gsVisitorNonLinearElasticityMM.h>
-#include <gsElasticity/gsVisitorElasticityNeumann.h>
+#include <gsElasticity/src/gsVisitorLinearElasticity.h>
+#include <gsElasticity/src/gsVisitorLinearElasticityMM.h>
+#include <gsElasticity/src/gsVisitorMixedLinearElasticity.h>
+#include <gsElasticity/src/gsVisitorMixedNonLinearElasticity.h>
+#include <gsElasticity/src/gsVisitorNonLinearElasticity.h>
+#include <gsElasticity/src/gsVisitorNonLinearElasticityMM.h>
+#include <gsElasticity/src/gsVisitorElasticityNeumann.h>
 
 namespace gismo
 {

--- a/src/gsElasticityAssembler_.cpp
+++ b/src/gsElasticityAssembler_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsElasticityAssembler.hpp>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElasticityAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsElasticityFunctions.h
+++ b/src/gsElasticityFunctions.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <gsCore/gsMultiPatch.h>
-#include <gsElasticity/gsBaseUtils.h>
+#include <gsElasticity/src/gsBaseUtils.h>
 #include <gsIO/gsOptionList.h>
 
 namespace gismo

--- a/src/gsElasticityFunctions.hpp
+++ b/src/gsElasticityFunctions.hpp
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsElasticityFunctions.h>
+#include <gsElasticity/src/gsElasticityFunctions.h>
 #include <gsCore/gsFuncData.h>
 #include <gsAssembler/gsAssembler.h>
 

--- a/src/gsElasticityFunctions_.cpp
+++ b/src/gsElasticityFunctions_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsElasticityFunctions.h>
-#include <gsElasticity/gsElasticityFunctions.hpp>
+#include <gsElasticity/src/gsElasticityFunctions.h>
+#include <gsElasticity/src/gsElasticityFunctions.hpp>
 
 namespace gismo
 {

--- a/src/gsGeoUtils.hpp
+++ b/src/gsGeoUtils.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsGeoUtils.h>
+#include <gsElasticity/src/gsGeoUtils.h>
 
 #include <gsCore/gsField.h>
 #include <gsCore/gsFuncData.h>
@@ -26,9 +26,9 @@
 #include <gsAssembler/gsQuadrature.h>
 #include <gsModeling/gsCoonsPatch.h>
 
-#include <gsElasticity/gsElasticityAssembler.h>
-#include <gsElasticity/gsElasticityFunctions.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElasticityFunctions.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 #include <gsUtils/gsMesh/gsMesh.h>
 #include <gsIO/gsWriteParaview.h>
 

--- a/src/gsGeoUtils_.cpp
+++ b/src/gsGeoUtils_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsGeoUtils.h>
-#include <gsElasticity/gsGeoUtils.hpp>
+#include <gsElasticity/src/gsGeoUtils.h>
+#include <gsElasticity/src/gsGeoUtils.hpp>
 
 namespace gismo
 {

--- a/src/gsIterative.h
+++ b/src/gsIterative.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include <gsIO/gsOptionList.h>
-#include <gsElasticity/gsBaseUtils.h>
+#include <gsElasticity/src/gsBaseUtils.h>
 #include <functional>
 
 namespace gismo

--- a/src/gsIterative.hpp
+++ b/src/gsIterative.hpp
@@ -15,9 +15,9 @@
 
 #pragma once
 
-#include <gsElasticity/gsIterative.h>
+#include <gsElasticity/src/gsIterative.h>
 
-#include <gsElasticity/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
 
 #include <sstream>
 

--- a/src/gsIterative_.cpp
+++ b/src/gsIterative_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsIterative.h>
-#include <gsElasticity/gsIterative.hpp>
+#include <gsElasticity/src/gsIterative.h>
+#include <gsElasticity/src/gsIterative.hpp>
 
 namespace gismo
 {

--- a/src/gsLinearMaterial.h
+++ b/src/gsLinearMaterial.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
 #include <gsCore/gsConstantFunction.h>
 
 namespace gismo

--- a/src/gsMassAssembler.h
+++ b/src/gsMassAssembler.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
 
 namespace gismo
 {

--- a/src/gsMassAssembler.hpp
+++ b/src/gsMassAssembler.hpp
@@ -15,9 +15,9 @@
 
 #pragma once
 
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsBasePde.h>
-#include <gsElasticity/gsVisitorMassElasticity.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsBasePde.h>
+#include <gsElasticity/src/gsVisitorMassElasticity.h>
 
 namespace gismo
 {

--- a/src/gsMassAssembler_.cpp
+++ b/src/gsMassAssembler_.cpp
@@ -1,8 +1,8 @@
 
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsMassAssembler.hpp>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsMaterialBase_.cpp
+++ b/src/gsMaterialBase_.cpp
@@ -1,7 +1,7 @@
 // #include <gsCore/gsTemplateTools.h>
 
-// #include <gsElasticity/src/gsMaterialBase.h>
-// #include <gsElasticity/src/gsMaterialBase.hpp>
+// #include <gsElasticity/src/src/gsMaterialBase.h>
+// #include <gsElasticity/src/src/gsMaterialBase.hpp>
 
 // namespace gismo
 // {

--- a/src/gsMaterialContainer.h
+++ b/src/gsMaterialContainer.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsMaterialBase.h>
+#include <gsElasticity/src/gsMaterialBase.h>
 
 namespace gismo
 {

--- a/src/gsMaterialEval.h
+++ b/src/gsMaterialEval.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <gsElasticity/gsMaterialUtils.h>
-#include <gsElasticity/gsMaterialContainer.h>
-#include <gsElasticity/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsMaterialUtils.h>
+#include <gsElasticity/src/gsMaterialContainer.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
 #include <gsCore/gsFunction.h>
 
 namespace gismo

--- a/src/gsMaterialEval.hpp
+++ b/src/gsMaterialEval.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsMaterialEval.h>
+#include <gsElasticity/src/gsMaterialEval.h>
 
 namespace gismo
 {

--- a/src/gsMaterialEval_.cpp
+++ b/src/gsMaterialEval_.cpp
@@ -1,7 +1,7 @@
 // #include <gsCore/gsTemplateTools.h>
 
-// #include <gsElasticity/gsMaterialEval.h>
-// // #include <gsElasticity/gsMaterialEval.hpp>
+// #include <gsElasticity/src/gsMaterialEval.h>
+// // #include <gsElasticity/src/gsMaterialEval.hpp>
 
 // namespace gismo
 // {

--- a/src/gsMaterial_.cpp
+++ b/src/gsMaterial_.cpp
@@ -1,8 +1,8 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsLinearMaterial.h>
-#include <gsElasticity/gsNeoHookeLogMaterial.h>
-#include <gsElasticity/gsNeoHookeQuadMaterial.h>
+#include <gsElasticity/src/gsLinearMaterial.h>
+#include <gsElasticity/src/gsNeoHookeLogMaterial.h>
+#include <gsElasticity/src/gsNeoHookeQuadMaterial.h>
 
 namespace gismo
 {

--- a/src/gsMooneyRivlinMaterial.h
+++ b/src/gsMooneyRivlinMaterial.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
 #include <gsUtils/gsThreaded.h>
 
 namespace gismo

--- a/src/gsMuscleAssembler.h
+++ b/src/gsMuscleAssembler.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
 
 namespace gismo
 {

--- a/src/gsMuscleAssembler.hpp
+++ b/src/gsMuscleAssembler.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <gsElasticity/gsMuscleAssembler.h>
+#include <gsElasticity/src/gsMuscleAssembler.h>
 
-#include <gsElasticity/gsGeoUtils.h>
+#include <gsElasticity/src/gsGeoUtils.h>
 
 // Element visitors
-#include <gsElasticity/gsVisitorMuscle.h>
-#include <gsElasticity/gsVisitorElasticityNeumann.h>
+#include <gsElasticity/src/gsVisitorMuscle.h>
+#include <gsElasticity/src/gsVisitorElasticityNeumann.h>
 
 namespace gismo
 {

--- a/src/gsMuscleAssembler_.cpp
+++ b/src/gsMuscleAssembler_.cpp
@@ -1,6 +1,6 @@
 #include <gsCore/gsTemplateTools.h>
-#include <gsElasticity/gsMuscleAssembler.h>
-#include <gsElasticity/gsMuscleAssembler.hpp>
+#include <gsElasticity/src/gsMuscleAssembler.h>
+#include <gsElasticity/src/gsMuscleAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsNeoHookeLogMaterial.h
+++ b/src/gsNeoHookeLogMaterial.h
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsMaterialBase.h>
+#include <gsElasticity/src/gsMaterialBase.h>
 #include <gsCore/gsConstantFunction.h>
 
 namespace gismo

--- a/src/gsNeoHookeQuadMaterial.h
+++ b/src/gsNeoHookeQuadMaterial.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <gsElasticity/gsMaterialBase.h>
+#include <gsElasticity/src/gsMaterialBase.h>
 #include <gsCore/gsConstantFunction.h>
 
 namespace gismo

--- a/src/gsNsAssembler.h
+++ b/src/gsNsAssembler.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
-#include <gsElasticity/gsBaseUtils.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseUtils.h>
 
 namespace gismo
 {
@@ -45,7 +45,7 @@ public:
     //--------------------- SYSTEM ASSEMBLY ----------------------------------//
 
     using Base::assemble;
-    
+
     /// @brief Assembly of the linear system for the Stokes problem
     /// @{
     virtual void assemble(bool saveEliminationMatrix);

--- a/src/gsNsAssembler.hpp
+++ b/src/gsNsAssembler.hpp
@@ -14,14 +14,14 @@
 
 #pragma once
 
-#include <gsElasticity/gsNsAssembler.h>
+#include <gsElasticity/src/gsNsAssembler.h>
 
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsBasePde.h>
 #include <gsUtils/gsPointGrid.h>
 
 // Element visitors
-#include <gsElasticity/gsVisitorStokes.h>
-#include <gsElasticity/gsVisitorNavierStokes.h>
+#include <gsElasticity/src/gsVisitorStokes.h>
+#include <gsElasticity/src/gsVisitorNavierStokes.h>
 
 namespace gismo
 {

--- a/src/gsNsAssembler_.cpp
+++ b/src/gsNsAssembler_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsNsAssembler.hpp>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsNsAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsNsTimeIntegrator.h
+++ b/src/gsNsTimeIntegrator.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <gsElasticity/gsBaseAssembler.h>
-#include <gsElasticity/gsBaseUtils.h>
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
+#include <gsElasticity/src/gsBaseAssembler.h>
+#include <gsElasticity/src/gsBaseUtils.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
 
 namespace gismo
 {

--- a/src/gsNsTimeIntegrator.hpp
+++ b/src/gsNsTimeIntegrator.hpp
@@ -15,11 +15,11 @@
 
 #pragma once
 
-#include <gsElasticity/gsNsTimeIntegrator.h>
+#include <gsElasticity/src/gsNsTimeIntegrator.h>
 
-#include <gsElasticity/gsNsAssembler.h>
-#include <gsElasticity/gsMassAssembler.h>
-#include <gsElasticity/gsIterative.h>
+#include <gsElasticity/src/gsNsAssembler.h>
+#include <gsElasticity/src/gsMassAssembler.h>
+#include <gsElasticity/src/gsIterative.h>
 
 namespace gismo
 {

--- a/src/gsNsTimeIntegrator_.cpp
+++ b/src/gsNsTimeIntegrator_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsNsTimeIntegrator.h>
-#include <gsElasticity/gsNsTimeIntegrator.hpp>
+#include <gsElasticity/src/gsNsTimeIntegrator.h>
+#include <gsElasticity/src/gsNsTimeIntegrator.hpp>
 
 namespace gismo
 {

--- a/src/gsPartitionedFSI.hpp
+++ b/src/gsPartitionedFSI.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <gsElasticity/gsPartitionedFSI.h>
+#include <gsElasticity/src/gsPartitionedFSI.h>
 
-#include <gsElasticity/gsNsTimeIntegrator.h>
-#include <gsElasticity/gsElTimeIntegrator.h>
-#include <gsElasticity/gsALE.h>
+#include <gsElasticity/src/gsNsTimeIntegrator.h>
+#include <gsElasticity/src/gsElTimeIntegrator.h>
+#include <gsElasticity/src/gsALE.h>
 #include <gsUtils/gsStopwatch.h>
-#include <gsElasticity/gsGeoUtils.h>
+#include <gsElasticity/src/gsGeoUtils.h>
 
 namespace gismo
 {

--- a/src/gsPartitionedFSI_.cpp
+++ b/src/gsPartitionedFSI_.cpp
@@ -1,7 +1,7 @@
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsPartitionedFSI.h>
-#include <gsElasticity/gsPartitionedFSI.hpp>
+#include <gsElasticity/src/gsPartitionedFSI.h>
+#include <gsElasticity/src/gsPartitionedFSI.hpp>
 
 namespace gismo
 {

--- a/src/gsThermoAssembler.h
+++ b/src/gsThermoAssembler.h
@@ -14,7 +14,7 @@
 */
 #pragma once
 
-#include <gsElasticity/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
 
 namespace gismo
 {

--- a/src/gsThermoAssembler.hpp
+++ b/src/gsThermoAssembler.hpp
@@ -15,10 +15,10 @@
 
 #pragma once
 
-#include <gsElasticity/gsThermoAssembler.h>
+#include <gsElasticity/src/gsThermoAssembler.h>
 
-#include <gsElasticity/gsVisitorThermo.h>
-#include <gsElasticity/gsVisitorThermoBoundary.h>
+#include <gsElasticity/src/gsVisitorThermo.h>
+#include <gsElasticity/src/gsVisitorThermoBoundary.h>
 
 namespace gismo
 {

--- a/src/gsThermoAssembler_.cpp
+++ b/src/gsThermoAssembler_.cpp
@@ -1,6 +1,6 @@
 #include <gsCore/gsTemplateTools.h>
-#include <gsElasticity/gsThermoAssembler.h>
-#include <gsElasticity/gsThermoAssembler.hpp>
+#include <gsElasticity/src/gsThermoAssembler.h>
+#include <gsElasticity/src/gsThermoAssembler.hpp>
 
 namespace gismo
 {

--- a/src/gsVisitorLinearElasticity.h
+++ b/src/gsVisitorLinearElasticity.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsVisitorElUtils.h>
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>

--- a/src/gsVisitorLinearElasticityMM.h
+++ b/src/gsVisitorLinearElasticityMM.h
@@ -15,11 +15,11 @@
 
 #pragma once
 
-#include <gsElasticity/gsVisitorElUtils.h>
-#include <gsElasticity/gsBasePde.h>
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsMaterialEval.h>
-#include <gsElasticity/gsMaterialContainer.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsMaterialEval.h>
+#include <gsElasticity/src/gsMaterialContainer.h>
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>

--- a/src/gsVisitorMixedLinearElasticity.h
+++ b/src/gsVisitorMixedLinearElasticity.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsVisitorElUtils.h>
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>

--- a/src/gsVisitorMixedNonLinearElasticity.h
+++ b/src/gsVisitorMixedNonLinearElasticity.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsVisitorElUtils.h>
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>

--- a/src/gsVisitorMuscle.h
+++ b/src/gsVisitorMuscle.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsVisitorElUtils.h>
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>

--- a/src/gsVisitorNavierStokes.h
+++ b/src/gsVisitorNavierStokes.h
@@ -18,7 +18,7 @@
 #include <gsCore/gsFuncData.h>
 #include <algorithm>
 
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 namespace gismo
 {

--- a/src/gsVisitorNonLinearElasticity.h
+++ b/src/gsVisitorNonLinearElasticity.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <gsElasticity/gsVisitorElUtils.h>
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>

--- a/src/gsVisitorNonLinearElasticityMM.h
+++ b/src/gsVisitorNonLinearElasticityMM.h
@@ -15,10 +15,10 @@
 
 #pragma once
 
-#include <gsElasticity/gsVisitorElUtils.h>
-#include <gsElasticity/gsBasePde.h>
-#include <gsElasticity/gsMaterialBase.h>
-#include <gsElasticity/gsMaterialContainer.h>
+#include <gsElasticity/src/gsVisitorElUtils.h>
+#include <gsElasticity/src/gsBasePde.h>
+#include <gsElasticity/src/gsMaterialBase.h>
+#include <gsElasticity/src/gsMaterialContainer.h>
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>

--- a/src/gsVisitorStokes.h
+++ b/src/gsVisitorStokes.h
@@ -16,7 +16,7 @@
 
 #include <gsAssembler/gsQuadrature.h>
 #include <gsCore/gsFuncData.h>
-#include <gsElasticity/gsBasePde.h>
+#include <gsElasticity/src/gsBasePde.h>
 
 namespace gismo
 {

--- a/src/gsWriteParaviewMultiPhysics.hpp
+++ b/src/gsWriteParaviewMultiPhysics.hpp
@@ -12,13 +12,13 @@
     Inspired by gsWriteParaview.hpp by A. Mantzaflaris
 */
 
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
 #include <gsUtils/gsPointGrid.h>
 #include <gsUtils/gsMesh/gsMesh.h>
 #include <gsCore/gsFunction.h>
 #include <gsCore/gsField.h>
 #include <gsIO/gsWriteParaview.h>
-#include <gsElasticity/gsGeoUtils.h>
+#include <gsElasticity/src/gsGeoUtils.h>
 
 
 #define PLOT_PRECISION 11

--- a/src/gsWriteParaviewMultiPhysics_.cpp
+++ b/src/gsWriteParaviewMultiPhysics_.cpp
@@ -1,8 +1,8 @@
 
 #include <gsCore/gsTemplateTools.h>
 
-#include <gsElasticity/gsWriteParaviewMultiPhysics.h>
-#include <gsElasticity/gsWriteParaviewMultiPhysics.hpp>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.h>
+#include <gsElasticity/src/gsWriteParaviewMultiPhysics.hpp>
 
 namespace gismo
 {

--- a/tutorials/linear_solid.cpp
+++ b/tutorials/linear_solid.cpp
@@ -14,7 +14,7 @@
 #include <gismo.h>
 
 //! [Includes]
-#include <gsElasticity/gsElasticityAssembler.h>
+#include <gsElasticity/src/gsElasticityAssembler.h>
 //! [Includes]
 
 using namespace gismo;


### PR DESCRIPTION
Removes the symbolic link to `gsElasticity/src`.
This symbolic link was creating problems when using [gismo](https://github.com/gismo/gismo) as a submodule in another project.

After this change, when including files from `gsElasticity/src`, in the old situation one could call 
```c++
include <gsElasticity/[file_from_src].h>
```
Now one has to call
```c++
include <gsElasticity/src/[file_from_src].h>
```